### PR TITLE
Add `requestBody` and `util.TableToJSON()` for API request

### DIFF
--- a/lua/autorun/server/sv_gmodainpc.lua
+++ b/lua/autorun/server/sv_gmodainpc.lua
@@ -129,12 +129,12 @@ meta.sendGPTRequest = function(this, text)
     }
 
     HTTP({
-        url = 'https://api.openai.com/v1/chat/completions',
-        type = 'application/json',
-        method = 'post',
+        url = "https://api.openai.com/v1/chat/completions",
+        type = "application/json",
+        method = "post",
         headers = {
-            ['Content-Type'] = 'application/json',
-            ['Authorization'] = 'Bearer ' .. _G.apiKey -- Access the API key from the Global table
+            ["Content-Type"] = "application/json",
+            ["Authorization"] = "Bearer " .. _G.apiKey -- Access the API key from the Global table
         },
         body = util.TableToJSON(requestBody),
 
@@ -163,13 +163,13 @@ meta.sendGPTRequest = function(this, text)
                 this:ChatPrint((response and response.error and
                                    response.error.message) and "Error! " ..
                                    response.error.message or
-                                   'Unknown error! api key is: ' .. _G.apiKey ..
+                                   "Unknown error! api key is: " .. _G.apiKey ..
                                    '')
             end
         end,
         failed = function(err)
             -- Print an error message if the HTTP request fails
-            ErrorNoHalt('HTTP Error: ' .. err)
+            ErrorNoHalt("HTTP Error: " .. err)
         end
     })
 end

--- a/lua/autorun/server/sv_gmodainpc.lua
+++ b/lua/autorun/server/sv_gmodainpc.lua
@@ -124,7 +124,7 @@ meta.sendGPTRequest = function(this, text)
                 content = text
             }
         },
-        max_tokens = 50, -- JSONToTable changes integers to float
+        max_tokens = 50, 
         temperature = 0.7
     }
 
@@ -140,7 +140,7 @@ meta.sendGPTRequest = function(this, text)
             ["Content-Type"] = "application/json",
             ["Authorization"] = "Bearer " .. _G.apiKey -- Access the API key from the Global table
         },
-        body = correctFloatToInt(util.TableToJSON(requestBody)),
+        body = correctFloatToInt(util.TableToJSON(requestBody)), -- tableToJSON changes integers to float
 
         success = function(code, body, headers)
             -- Parse the JSON response from the GPT-3 API

--- a/lua/autorun/server/sv_gmodainpc.lua
+++ b/lua/autorun/server/sv_gmodainpc.lua
@@ -124,9 +124,13 @@ meta.sendGPTRequest = function(this, text)
                 content = text
             }
         },
-        max_tokens = 50,
+        max_tokens = 50, -- JSONToTable changes integers to float
         temperature = 0.7
     }
+
+    local function correctFloatToInt(jsonString)
+        return string.gsub(jsonString, '(%d+)%.0', '%1')
+    end
 
     HTTP({
         url = "https://api.openai.com/v1/chat/completions",
@@ -136,7 +140,7 @@ meta.sendGPTRequest = function(this, text)
             ["Content-Type"] = "application/json",
             ["Authorization"] = "Bearer " .. _G.apiKey -- Access the API key from the Global table
         },
-        body = util.TableToJSON(requestBody),
+        body = correctFloatToInt(util.TableToJSON(requestBody)),
 
         success = function(code, body, headers)
             -- Parse the JSON response from the GPT-3 API

--- a/lua/autorun/server/sv_gmodainpc.lua
+++ b/lua/autorun/server/sv_gmodainpc.lua
@@ -116,6 +116,18 @@ local meta = FindMetaTable("Player")
 -- Extend the Player metatable to add a custom function for sending requests to GPT-3
 meta.sendGPTRequest = function(this, text)
     -- Use the HTTP library to make a request to the GPT-3 API
+    local requestBody = {
+        model = "gpt-3.5-turbo",
+        messages = {
+            {
+                role = "user",
+                content = text
+            }
+        },
+        max_tokens = 50,
+        temperature = 0.7
+    }
+
     HTTP({
         url = 'https://api.openai.com/v1/chat/completions',
         type = 'application/json',
@@ -124,12 +136,8 @@ meta.sendGPTRequest = function(this, text)
             ['Content-Type'] = 'application/json',
             ['Authorization'] = 'Bearer ' .. _G.apiKey -- Access the API key from the Global table
         },
-        body = [[{
-            "model": "gpt-3.5-turbo",
-            "messages": [{"role": "user", "content": "]] .. text .. [["}],
-            "max_tokens": 50,
-            "temperature": 0.7
-        }]],
+        body = util.TableToJSON(requestBody),
+
         success = function(code, body, headers)
             -- Parse the JSON response from the GPT-3 API
             local response = util.JSONToTable(body)


### PR DESCRIPTION
Integrated `util.TableToJSON()` to serialize the `requestBody` into a JSON string for the API call.