### PR TITLE
Multi NPC Memory, Free LLM Providers, and TTS Position Update

### DIFF
--- a/lua/autorun/client/cl_gmodainpc.lua
+++ b/lua/autorun/client/cl_gmodainpc.lua
@@ -50,15 +50,23 @@ function drawaihud()
     providerDropdown:SetPos(10, 80) -- Set the position of the dropdown menu
     providerDropdown:SetSize(170, 20) -- Set the size of the dropdown menu
     providerDropdown:SetValue("openai") -- Set the default value
-    providerDropdown:AddChoice("openai") -- Add "openai" as an option
-    providerDropdown:AddChoice("openrouter") -- Add "openrouter" as an option
+    providerDropdown:AddChoice("openai")
+    providerDropdown:AddChoice("openrouter")
+    providerDropdown:AddChoice("groq") 
+
+    local modelLabel = vgui.Create("DLabel", rightPanel)
+    modelLabel:SetText("Model:")
+    modelLabel:SetPos(10, 110)
+
+    local modelDropdown = vgui.Create("DComboBox", rightPanel)
+    modelDropdown:SetPos(10, 130)
 
     local npcLabel = vgui.Create("DLabel", rightPanel) -- Create a label for NPC selection
     npcLabel:SetText("Select NPC:") -- Set the text of the label
-    npcLabel:SetPos(10, 110) -- Set the position of the label
+    npcLabel:SetPos(10, 160) -- Set the position of the label
 
     local npcDropdown = vgui.Create("DComboBox", rightPanel) -- Create a dropdown menu for NPC selection
-    npcDropdown:SetPos(10, 130) -- Set the position of the dropdown menu
+    npcDropdown:SetPos(10, 180) -- Set the position of the dropdown menu
     npcDropdown:SetSize(170, 20) -- Set the size of the dropdown menu
     npcDropdown:SetValue("npc_citizen") -- Set the default value to "npc_citizen"
 
@@ -68,16 +76,16 @@ function drawaihud()
 
     local apiKeyLabel = vgui.Create("DLabel", rightPanel) -- Create a label for the API key
     apiKeyLabel:SetText("API Key:") -- Set the text of the label
-    apiKeyLabel:SetPos(10, 160) -- Set the position of the label
+    apiKeyLabel:SetPos(10, 210) -- Set the position of the label
 
     local apiKeyEntry = vgui.Create("DTextEntry", rightPanel) -- Create a text entry for the API key
-    apiKeyEntry:SetPos(10, 180) -- Set the position of the text entry
+    apiKeyEntry:SetPos(10, 230) -- Set the position of the text entry
     apiKeyEntry:SetSize(170, 20) -- Set the size of the text entry
     apiKeyEntry:SetText(inputapikey) -- Set the default text of the text entry
 
     local freeAPIButton = vgui.Create("DCheckBoxLabel", rightPanel) -- Create a checkbox for enabling "Free API"
     freeAPIButton:SetText("Free API") -- Set the text of the checkbox
-    freeAPIButton:SetPos(10, 210) -- Set the position of the checkbox
+    freeAPIButton:SetPos(10, 260) -- Set the position of the checkbox
     freeAPIButton:SetSize(170, 20) -- Set the size of the checkbox
 
     freeAPIButton.OnChange = function(self, value)
@@ -91,22 +99,17 @@ function drawaihud()
 
     local TTSButton = vgui.Create("DCheckBoxLabel", rightPanel) -- Create a button for creating the NPC
     TTSButton:SetText("Text to Speech") -- Set the text of the button
-    TTSButton:SetPos(10, 230) -- Nice, Set the position of the button
+    TTSButton:SetPos(10, 280) -- Nice, Set the position of the button
     TTSButton:SetSize(170, 20) -- Set the size of the button
     TTSButton:SetValue(0)
 
     local createButton = vgui.Create("DButton", rightPanel) -- Create a button for creating the NPC
     createButton:SetText("Create NPC") -- Set the text of the button
-    createButton:SetPos(10, 260) -- Set the position of the button
+    createButton:SetPos(10, 310) -- Set the position of the button
     createButton:SetSize(170, 60) -- Set the size of the button
 
     createButton.DoClick = function()
         inputapikey = apiKeyEntry:GetValue()
-
-        -- Send provider selection
-        net.Start("SendProvider")
-        net.WriteString(providerDropdown:GetValue())
-        net.SendToServer()
 
         -- Send API key
         if freeAPIButton:GetChecked() then
@@ -121,14 +124,14 @@ function drawaihud()
             apiKey = APIKEY,
             personality = aiLinkEntry:GetValue(),
             selectedNPC = npcDropdown:GetValue(),
-            enableTTS = TTSButton:GetChecked()
+            enableTTS = TTSButton:GetChecked(),
+            provider = providerDropdown:GetValue()
         }
 
         net.Start("SendNPCInfo")
         net.WriteTable(requestBody)
         net.SendToServer()
     end
-
 end
 
 soundList = {}

--- a/lua/autorun/client/cl_gmodainpc.lua
+++ b/lua/autorun/client/cl_gmodainpc.lua
@@ -88,18 +88,13 @@ function drawaihud()
     npcDropdown:SetValue("npc_citizen") -- Set the default value to "npc_citizen"
 
     -- Get the list of all NPCs and populate the dropdown menu
-    local modelTable = player_manager.AllValidModels()
-    for modelClass, modelPath in pairs(modelTable) do    
-        if not string.match(modelPath, "/c_") and not string.match(modelPath, "/v_") then
-            npcDropdown:AddChoice(modelClass, {
-                model = modelPath,
-                class = modelClass
-            })
-        end
+    local npcTable = ents._SpawnMenuNPCs
+    for npcId, npcData in pairs(npcTable) do    
+        npcDropdown:AddChoice(npcId, npcData)
     end
     
     function npcDropdown:OnSelect(self, idx, data)
-        modelPanel:SetModel(data.model)
+        modelPanel:SetModel(data.Model)
     end
     
     local apiKeyLabel = vgui.Create("DLabel", rightPanel) -- Create a label for the API key

--- a/lua/autorun/client/cl_gmodainpc.lua
+++ b/lua/autorun/client/cl_gmodainpc.lua
@@ -94,29 +94,20 @@ function drawaihud()
         if freeAPIButton:GetChecked() then
             -- Please dont steal our API key, we are poor
             -- TODO Change this to a encrypted key using server encrypt function
-            local APIKEY = "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"
-            net.Start("SendAPIKey")
-            net.WriteString(APIKEY)
-            net.SendToServer()
+            APIKEY = "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"
         else
-            net.Start("SendAPIKey")
-            net.WriteString(apiKeyEntry:GetValue())
-            net.SendToServer()
+            APIKEY = apiKeyEntry:GetValue()
         end
 
-        -- Send AI personality
-        net.Start("SendPersonality")
-        net.WriteString(aiLinkEntry:GetValue())
-        net.SendToServer()
+        local requestBody = {
+            apiKey = APIKEY,
+            personality = aiLinkEntry:GetValue(),
+            selectedNPC = npcDropdown:GetValue(),
+            enableTTS = TTSButton:GetChecked()
+        }
 
-        -- Send selected NPC class
-        net.Start("SendSelectedNPC")
-        net.WriteString(npcDropdown:GetValue())
-        net.SendToServer()
-
-        -- Send if TTS should be enabled
-        net.Start("SendTTS")
-        net.WriteBool(TTSButton:GetChecked())
+        net.Start("SendNPCInfo")
+        net.WriteTable(requestBody)
         net.SendToServer()
     end
 

--- a/lua/autorun/client/cl_gmodainpc.lua
+++ b/lua/autorun/client/cl_gmodainpc.lua
@@ -63,6 +63,7 @@ function drawaihud()
     apiKeyEntry:SetPos(10, 130) -- Set the position of the text entry
     apiKeyEntry:SetSize(170, 20) -- Set the size of the text entry
     apiKeyEntry:SetText(inputapikey) -- Set the default text of the text entry
+    
     local freeAPIButton = vgui.Create("DCheckBoxLabel", rightPanel) -- Create a checkbox for enabling "Free API"
     freeAPIButton:SetText("Free API") -- Set the text of the checkbox
     freeAPIButton:SetPos(10, 155) -- Set the position of the checkbox
@@ -113,8 +114,11 @@ function drawaihud()
 
 end
 
+soundList = {}
+
 -- TODO Convert this to serverside code so that audio can changed to follow NPC
 net.Receive("SayTTS", function()
+    local key = net.ReadString()
     local text = net.ReadString() -- Read the TTS text from the network
     local ply = net.ReadEntity() -- Read the player entity from the network
     text = string.sub(string.Replace(text, " ", "%20"), 1, 1000) -- Replace spaces with "%20" and limit the text length to 100 characters
@@ -128,16 +132,14 @@ net.Receive("SayTTS", function()
                 sound:SetVolume(1) -- Set the sound volume to maximum
                 sound:Play() -- Play the sound
                 sound:Set3DFadeDistance(200, 1000) -- Set the 3D sound fade distance
-                ply.sound = sound -- Store the sound reference in the player entity
+                soundList[key] = sound -- Store the sound reference in the player entity
             end
         end)
 end)
 
--- Update the position of the TTS sound for all players
-hook.Add("Think", "FollowPlayerSound", function()
-    for k, v in pairs(player.GetAll()) do
-        if IsValid(v.sound) then
-            v.sound:SetPos(v:GetPos()) -- Set the sound position to the player's position
-        end
-    end
+net.Receive("TTSPositionUpdate", function()
+    local key = net.ReadString()
+    local pos = net.ReadVector()
+
+    soundList[key]:SetPos(pos)
 end)

--- a/lua/autorun/client/cl_gmodainpc.lua
+++ b/lua/autorun/client/cl_gmodainpc.lua
@@ -8,7 +8,7 @@ list.Set("DesktopWindows", "ai_menu", {
 
 function drawaihud()
     local frame = vgui.Create("DFrame") -- Create a frame for the character selection panel
-    frame:SetSize(400, 380) -- Set the size of the frame
+    frame:SetSize(400, 480) -- Set the size of the frame
     frame:SetTitle("Character Selection") -- Set the title of the frame
     frame:Center() -- Center the frame on the screen
     frame:MakePopup() -- Make the frame a popup
@@ -52,40 +52,59 @@ function drawaihud()
     providerDropdown:SetValue("openai") -- Set the default value
     providerDropdown:AddChoice("openai")
     providerDropdown:AddChoice("openrouter")
-    providerDropdown:AddChoice("groq") 
+    providerDropdown:AddChoice("groq")
+    providerDropdown:AddChoice("ollama")
+
+    local hostnameLabel = vgui.Create("DLabel", rightPanel)
+    hostnameLabel:SetText("Hostname:")
+    hostnameLabel:SetPos(10, 110)
+
+    local hostnameEntry = vgui.Create("DTextEntry", rightPanel)
+    hostnameEntry:SetPos(10, 130)
+    hostnameEntry:SetSize(170, 20)
+
+    providerDropdown.OnSelect = function(self, value)
+        if value == "ollama" then
+            hostnameEntry:SetEditable(true)
+        else
+            hostnameEntry:SetEditable(false)
+        end
+    end
 
     local modelLabel = vgui.Create("DLabel", rightPanel)
     modelLabel:SetText("Model:")
-    modelLabel:SetPos(10, 110)
+    modelLabel:SetPos(10, 160)
 
     local modelDropdown = vgui.Create("DComboBox", rightPanel)
-    modelDropdown:SetPos(10, 130)
+    modelDropdown:SetPos(10, 180)
 
     local npcLabel = vgui.Create("DLabel", rightPanel) -- Create a label for NPC selection
     npcLabel:SetText("Select NPC:") -- Set the text of the label
-    npcLabel:SetPos(10, 160) -- Set the position of the label
+    npcLabel:SetPos(10, 210) -- Set the position of the label
 
     local npcDropdown = vgui.Create("DComboBox", rightPanel) -- Create a dropdown menu for NPC selection
-    npcDropdown:SetPos(10, 180) -- Set the position of the dropdown menu
+    npcDropdown:SetPos(10, 230) -- Set the position of the dropdown menu
     npcDropdown:SetSize(170, 20) -- Set the size of the dropdown menu
     npcDropdown:SetValue("npc_citizen") -- Set the default value to "npc_citizen"
 
     -- Get the list of all NPCs and populate the dropdown menu
     local npcTable = list.Get("NPC")
-    for npcClass, _ in pairs(npcTable) do npcDropdown:AddChoice(npcClass) end
+    for npcClass, npcData in pairs(npcTable) do
+        npcDropdown:AddChoice(npcClass, npcData.Model)
+    end
 
     local apiKeyLabel = vgui.Create("DLabel", rightPanel) -- Create a label for the API key
     apiKeyLabel:SetText("API Key:") -- Set the text of the label
-    apiKeyLabel:SetPos(10, 210) -- Set the position of the label
+    apiKeyLabel:SetPos(10, 260) -- Set the position of the label
 
     local apiKeyEntry = vgui.Create("DTextEntry", rightPanel) -- Create a text entry for the API key
-    apiKeyEntry:SetPos(10, 230) -- Set the position of the text entry
+    apiKeyEntry:SetPos(10, 280) -- Set the position of the text entry
     apiKeyEntry:SetSize(170, 20) -- Set the size of the text entry
     apiKeyEntry:SetText(inputapikey) -- Set the default text of the text entry
 
     local freeAPIButton = vgui.Create("DCheckBoxLabel", rightPanel) -- Create a checkbox for enabling "Free API"
     freeAPIButton:SetText("Free API") -- Set the text of the checkbox
-    freeAPIButton:SetPos(10, 260) -- Set the position of the checkbox
+    freeAPIButton:SetPos(10, 310) -- Set the position of the checkbox
     freeAPIButton:SetSize(170, 20) -- Set the size of the checkbox
 
     freeAPIButton.OnChange = function(self, value)
@@ -99,13 +118,13 @@ function drawaihud()
 
     local TTSButton = vgui.Create("DCheckBoxLabel", rightPanel) -- Create a button for creating the NPC
     TTSButton:SetText("Text to Speech") -- Set the text of the button
-    TTSButton:SetPos(10, 280) -- Nice, Set the position of the button
+    TTSButton:SetPos(10, 330) -- Nice, Set the position of the button
     TTSButton:SetSize(170, 20) -- Set the size of the button
     TTSButton:SetValue(0)
 
     local createButton = vgui.Create("DButton", rightPanel) -- Create a button for creating the NPC
     createButton:SetText("Create NPC") -- Set the text of the button
-    createButton:SetPos(10, 310) -- Set the position of the button
+    createButton:SetPos(10, 360) -- Set the position of the button
     createButton:SetSize(170, 60) -- Set the size of the button
 
     createButton.DoClick = function()

--- a/lua/autorun/client/cl_gmodainpc.lua
+++ b/lua/autorun/client/cl_gmodainpc.lua
@@ -150,14 +150,10 @@ function drawaihud()
             apiKey = APIKEY,
             hostname = hostnameEntry:GetValue(),
             personality = aiLinkEntry:GetValue(),
-            NPCClass = 'npc_citizen',
+            NPCData = selectedNPC,
             enableTTS = TTSButton:GetChecked(),
             provider = provider
         }
-
-        if selectedNPC and selectedNPC.model then
-            requestBody.NPCModel = selectedNPC.model
-        end
 
         net.Start("SendNPCInfo")
         net.WriteTable(requestBody)

--- a/lua/autorun/server/sv_gmodainpc.lua
+++ b/lua/autorun/server/sv_gmodainpc.lua
@@ -31,6 +31,7 @@ net.Receive("SendNPCInfo", function(len, ply)
     spawnedNPC[key]["history"] = {}
 
     spawnedNPC[key]["provider"] = data["provider"]
+    spawnedNPC[key]["hostname"] = data["hostname"]
     spawnedNPC[key]["apiKey"] = apiKey
     spawnedNPC[key]["max_tokens"] = 50
     spawnedNPC[key]["temperature"] = 0.7
@@ -43,8 +44,8 @@ net.Receive("SendNPCInfo", function(len, ply)
                                      personality ..
                                      "if you understand, respond with a hello in character" -- Set the personality in the Global table
 
-    local selectedNPC = data["selectedNPC"]
-    print("Selected NPC: " .. selectedNPC)
+    local NPCClass = data["NPCClass"]
+    local NPCModel = data["NPCModel"]
 
     -- Calculate spawn position in front of the player
     local spawnPosition = ply:GetEyeTrace().HitPos
@@ -53,7 +54,7 @@ net.Receive("SendNPCInfo", function(len, ply)
     local spawnAngle = Angle(0, math.random(0, 360), 0)
 
     -- Spawn the selected NPC with the random angle
-    spawnedNPC[key]["npc"] = SpawnNPC(spawnPosition, spawnAngle, selectedNPC, key)
+    spawnedNPC[key]["npc"] = SpawnNPC(spawnPosition, spawnAngle, NPCClass, NPCModel, key)
 
     if IsValid(spawnedNPC) then
         print("NPC spawned successfully!")
@@ -74,13 +75,14 @@ net.Receive("SendNPCInfo", function(len, ply)
 end)
 
 -- Define SpawnNPC function
-function SpawnNPC(pos, ang, npcClass, key)
+function SpawnNPC(pos, ang, npcClass, npcModel, key)
     local npc = ents.Create(npcClass)
     if not IsValid(npc) then return end
 
     npc:SetPos(pos)
     npc:SetAngles(ang)
     npc:Spawn()
+    if npcModel then npc:SetModel(npcModel) end
 
     -- Set up a hook for the NPC's death event
     hook.Add("OnNPCKilled", "OnAIDeath", function(npc, attacker, inflictor)

--- a/lua/autorun/server/sv_gmodainpc.lua
+++ b/lua/autorun/server/sv_gmodainpc.lua
@@ -1,4 +1,6 @@
 -- Add network strings for communication between client and server
+util.AddNetworkString("GetNPCModel")
+util.AddNetworkString("RespondNPCModel")
 util.AddNetworkString("SendNPCInfo")
 util.AddNetworkString("SayTTS")
 util.AddNetworkString("TTSPositionUpdate")
@@ -6,6 +8,36 @@ util.AddNetworkString("TTSPositionUpdate")
 providers = include('providers/providers.lua')
 
 local spawnedNPC = {} -- Variable to store the reference to the spawned NPC
+
+net.Receive("GetNPCModel", function(len, ply)
+    local NPCData = net.ReadTable()
+    local model
+
+    if !NPCData.Model then
+        local entity = ents.Create(NPCData.Class)
+        entity:Spawn()
+        
+        -- Hide NPC everywhere except inside model panel
+        entity:SetSaveValue("m_takedamage", 0)
+        entity:SetMoveType(MOVETYPE_NONE)
+        entity:SetSolid(SOLID_NONE)
+        entity:SetRenderMode(RENDERMODE_TRANSALPHA)
+        entity:SetColor(Color(255, 255, 255, 0))
+
+        if !IsValid(entity) then return end
+
+        model = entity:GetModel()
+        
+        entity:Remove()
+    else
+        model = NPCData.Model
+    end
+
+    net.Start("RespondNPCModel")
+    net.WriteString(model)
+    net.Send(ply)
+
+end)
 
 net.Receive("SendNPCInfo", function(len, ply)
     local data = net.ReadTable()

--- a/lua/providers/groq.lua
+++ b/lua/providers/groq.lua
@@ -1,0 +1,47 @@
+local groqProvider = {}
+
+groqProvider.models = {
+    "gemma2-9b-it",
+    "llama-3.3-70b-versatile",
+    "llama-3.1-8b-instant",
+    "llama3-70b-8192",
+    "llama3-8b-8192",
+    "mixtral-8x7b-32768"
+}
+
+function groqProvider.request(apiKey, model, messages, max_tokens, temperature, callback)
+    local function correctFloatToInt(jsonString)
+        return string.gsub(jsonString, '(%d+)%.0', '%1')
+    end
+
+    local requestBody = {
+        model = 'llama-3.1-8b-instant',
+        messages = messages,
+        max_tokens = max_tokens, 
+        temperature = temperature
+    }
+
+    HTTP({
+        url = "https://api.groq.com/openai/v1/chat/completions",
+        type = "application/json",
+        method = "post",
+        headers = {
+            ["Content-Type"] = "application/json",
+            ["Authorization"] = "Bearer " .. apiKey -- Access the API key from the Global table
+        },
+        body = correctFloatToInt(util.TableToJSON(requestBody)), -- tableToJSON changes integers to float
+
+        success = function(code, body, headers)
+            -- Parse the JSON response from the GPT-3 API
+            local response = util.JSONToTable(body)
+
+            callback(nil, response)
+        end,
+        failed = function(err)
+            -- Print an error message if the HTTP request fails
+            callback("HTTP Error: " .. err, nil)
+        end
+    })
+end
+
+return groqProvider

--- a/lua/providers/groq.lua
+++ b/lua/providers/groq.lua
@@ -9,16 +9,16 @@ groqProvider.models = {
     "mixtral-8x7b-32768"
 }
 
-function groqProvider.request(apiKey, model, messages, max_tokens, temperature, callback)
+function groqProvider.request(npc, callback)
     local function correctFloatToInt(jsonString)
         return string.gsub(jsonString, '(%d+)%.0', '%1')
     end
 
     local requestBody = {
         model = 'llama-3.1-8b-instant',
-        messages = messages,
-        max_tokens = max_tokens, 
-        temperature = temperature
+        messages = npc["history"],
+        max_tokens = npc["max_tokens"], 
+        temperature = npc["temperature"]
     }
 
     HTTP({
@@ -27,7 +27,7 @@ function groqProvider.request(apiKey, model, messages, max_tokens, temperature, 
         method = "post",
         headers = {
             ["Content-Type"] = "application/json",
-            ["Authorization"] = "Bearer " .. apiKey -- Access the API key from the Global table
+            ["Authorization"] = "Bearer " .. npc["apiKey"] -- Access the API key from the Global table
         },
         body = correctFloatToInt(util.TableToJSON(requestBody)), -- tableToJSON changes integers to float
 

--- a/lua/providers/ollama.lua
+++ b/lua/providers/ollama.lua
@@ -1,19 +1,24 @@
-local openrouterProvider = {}
+local ollamaProvider = {}
 
-function openrouterProvider.request(npc, callback)
+function ollamaProvider.request(npc, callback)
     local function correctFloatToInt(jsonString)
         return string.gsub(jsonString, '(%d+)%.0', '%1')
     end
 
+    if not npc["hostname"] then
+        ErrorNoHalt("Hostname not defined")
+    end
+
     local requestBody = {
-        model = 'huggingfaceh4/zephyr-7b-beta:free',
+        model = "llama3:latest",
         messages = npc["history"],
         max_tokens = npc["max_tokens"], 
-        temperature = npc["temperature"]
+        temperature = npc["temperature"],
+        stream = false
     }
 
     HTTP({
-        url = "https://openrouter.ai/api/v1/chat/completions",
+        url = "http://" .. npc["hostname"] .. "/api/chat",
         type = "application/json",
         method = "post",
         headers = {
@@ -26,6 +31,16 @@ function openrouterProvider.request(npc, callback)
             -- Parse the JSON response from the GPT-3 API
             local response = util.JSONToTable(body)
 
+            -- Add choices list to match ollama output to GPT output
+            response.choices = {
+                {
+                    message = {
+                        role = response.message.role
+                        content = response.message.content
+                    }
+                }
+            }
+
             callback(nil, response)
         end,
         failed = function(err)
@@ -35,4 +50,4 @@ function openrouterProvider.request(npc, callback)
     })
 end
 
-return openrouterProvider
+return ollamaProvider

--- a/lua/providers/ollama.lua
+++ b/lua/providers/ollama.lua
@@ -35,7 +35,7 @@ function ollamaProvider.request(npc, callback)
             response.choices = {
                 {
                     message = {
-                        role = response.message.role
+                        role = response.message.role,
                         content = response.message.content
                     }
                 }

--- a/lua/providers/openai.lua
+++ b/lua/providers/openai.lua
@@ -8,16 +8,16 @@ openAiProvider.models = {
     "gpt-3.5-turbo"
 }
 
-function openAiProvider.request(apiKey, model, messages, max_tokens, temperature, callback)
+function openAiProvider.request(npc, callback)
     local function correctFloatToInt(jsonString)
         return string.gsub(jsonString, '(%d+)%.0', '%1')
     end
 
     local requestBody = {
         model = 'gpt-4o-mini',
-        messages = messages,
-        max_tokens = max_tokens, 
-        temperature = temperature
+        messages = npc["history"],
+        max_tokens = npc["max_tokens"], 
+        temperature = npc["temperature"]
     }
 
     HTTP({
@@ -26,7 +26,7 @@ function openAiProvider.request(apiKey, model, messages, max_tokens, temperature
         method = "post",
         headers = {
             ["Content-Type"] = "application/json",
-            ["Authorization"] = "Bearer " .. apiKey -- Access the API key from the Global table
+            ["Authorization"] = "Bearer " .. npc["apiKey"] -- Access the API key from the Global table
         },
         body = correctFloatToInt(util.TableToJSON(requestBody)), -- tableToJSON changes integers to float
 

--- a/lua/providers/openai.lua
+++ b/lua/providers/openai.lua
@@ -1,0 +1,46 @@
+local openAiProvider = {}
+
+openAiProvider.models = {
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gpt-4-turbo",
+    "gpt-4",
+    "gpt-3.5-turbo"
+}
+
+function openAiProvider.request(apiKey, model, messages, max_tokens, temperature, callback)
+    local function correctFloatToInt(jsonString)
+        return string.gsub(jsonString, '(%d+)%.0', '%1')
+    end
+
+    local requestBody = {
+        model = 'gpt-4o-mini',
+        messages = messages,
+        max_tokens = max_tokens, 
+        temperature = temperature
+    }
+
+    HTTP({
+        url = "https://api.openai.com/v1/chat/completions",
+        type = "application/json",
+        method = "post",
+        headers = {
+            ["Content-Type"] = "application/json",
+            ["Authorization"] = "Bearer " .. apiKey -- Access the API key from the Global table
+        },
+        body = correctFloatToInt(util.TableToJSON(requestBody)), -- tableToJSON changes integers to float
+
+        success = function(code, body, headers)
+            -- Parse the JSON response from the GPT-3 API
+            local response = util.JSONToTable(body)
+
+            callback(nil, response)
+        end,
+        failed = function(err)
+            -- Print an error message if the HTTP request fails
+            callback("HTTP Error: " .. err, nil)
+        end
+    })
+end
+
+return openAiProvider

--- a/lua/providers/openrouter.lua
+++ b/lua/providers/openrouter.lua
@@ -1,0 +1,38 @@
+local openrouterProvider = {}
+
+function openrouterProvider.request(apiKey, model, messages, max_tokens, temperature, callback)
+    local function correctFloatToInt(jsonString)
+        return string.gsub(jsonString, '(%d+)%.0', '%1')
+    end
+
+    local requestBody = {
+        model = 'huggingfaceh4/zephyr-7b-beta:free',
+        messages = messages,
+        max_tokens = max_tokens, 
+        temperature = temperature
+    }
+
+    HTTP({
+        url = "https://openrouter.ai/api/v1/chat/completions",
+        type = "application/json",
+        method = "post",
+        headers = {
+            ["Content-Type"] = "application/json",
+            ["Authorization"] = "Bearer " .. apiKey -- Access the API key from the Global table
+        },
+        body = correctFloatToInt(util.TableToJSON(requestBody)), -- tableToJSON changes integers to float
+
+        success = function(code, body, headers)
+            -- Parse the JSON response from the GPT-3 API
+            local response = util.JSONToTable(body)
+
+            callback(nil, response)
+        end,
+        failed = function(err)
+            -- Print an error message if the HTTP request fails
+            callback("HTTP Error: " .. err, nil)
+        end
+    })
+end
+
+return openrouterProvider

--- a/lua/providers/providers.lua
+++ b/lua/providers/providers.lua
@@ -1,0 +1,18 @@
+local providers = {}
+
+function providers.get(name)
+    print(name)
+    if name == "openai" then
+        provider = include("providers/openai.lua")
+    elseif name == "groq" then
+        provider = include("providers/groq.lua")
+    elseif name == "openrouter" then
+        provider = include("providers/openrouter.lua")
+    else
+        error("Unsupported provider: " .. name) 
+    end
+
+    return provider
+end
+
+return providers

--- a/lua/providers/providers.lua
+++ b/lua/providers/providers.lua
@@ -4,6 +4,8 @@ function providers.get(name)
     print(name)
     if name == "openai" then
         provider = include("providers/openai.lua")
+    elseif name == "ollama" then
+        provider = include("providers/ollama.lua")
     elseif name == "groq" then
         provider = include("providers/groq.lua")
     elseif name == "openrouter" then


### PR DESCRIPTION
- NPCs now have memory
- You can have multiple NPCs. But currently all NPCs will respond in one command.
- TTS sound tracks each of the NPCs.
- You can set addon models to NPCs.

Additional LLM Providers
 - Groq
 - OpenRouter
 - Ollama (Only available on dedicated server with parameter `-allowlocalhttp`)