### PR TITLE
Migrate deprecated ents._SpawnMenuNPCs

### DIFF
--- a/lua/autorun/client/cl_gmodainpc.lua
+++ b/lua/autorun/client/cl_gmodainpc.lua
@@ -121,7 +121,7 @@ function drawaihud()
         net.WriteTable(data)
         net.SendToServer()
     end
-    for npcId, npcData in pairs(ents._SpawnMenuNPCs) do
+    for npcId, npcData in pairs(list.Get("NPC")) do
         npcData.Id = npcId
         npcDropdown:AddChoice(npcId, npcData)
     end


### PR DESCRIPTION
This caused NPC spawn menu not loading properly.