### PR TITLE
Revamp AI NPC UI, Expand Model Support, and Gate Logging to Developer Mode

### DIFF
--- a/lua/autorun/client/cl_gmodainpc.lua
+++ b/lua/autorun/client/cl_gmodainpc.lua
@@ -440,12 +440,35 @@ function drawaihud()
     end
 
     function providerDropdown:OnSelect(index, value, data)
+        local previousProviderId = currentProviderId
         currentProviderId = data or value
-        if currentProviderId == "ollama" then
-            hostnameEntry:SetEditable(true)
+
+        local isOllama = currentProviderId == "ollama"
+
+        hostnameEntry:SetEditable(isOllama)
+
+        if isOllama then
+            apiKeyLabel:SetText("API Key (optional):")
+            freeAPIButton:SetVisible(false)
+
+            if freeAPIButton:GetChecked() then
+                freeAPIButton:SetChecked(false)
+            else
+                apiKeyEntry:SetEditable(true)
+            end
         else
-            hostnameEntry:SetEditable(false)
+            apiKeyLabel:SetText("API Key:")
+            freeAPIButton:SetVisible(true)
+
+            if not freeAPIButton:GetChecked() then
+                apiKeyEntry:SetEditable(true)
+            end
+
+            if previousProviderId == "ollama" and inputapikey and inputapikey ~= "" then
+                apiKeyEntry:SetText(inputapikey)
+            end
         end
+
         populateModels(currentProviderId)
     end
 
@@ -471,10 +494,19 @@ function drawaihud()
     createButton:Dock(TOP)
     createButton:DockMargin(0, 20, 0, 0)
     createButton.DoClick = function()
-        inputapikey = apiKeyEntry:GetValue()
-        local APIKEY = freeAPIButton:GetChecked() and
-            "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" or
-            apiKeyEntry:GetValue()
+        local enteredKey = apiKeyEntry:GetValue()
+        if currentProviderId ~= "ollama" and not freeAPIButton:GetChecked() then
+            inputapikey = enteredKey
+        end
+
+        local APIKEY
+        if currentProviderId == "ollama" then
+            APIKEY = enteredKey or ""
+        else
+            APIKEY = freeAPIButton:GetChecked() and
+                "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" or
+                enteredKey
+        end
 
         local selectedNPCPanel = npcDropdown:GetSelected()
         local selectedNPC = selectedNPCPanel and selectedNPCPanel.Data or selectedNPCData

--- a/lua/autorun/client/cl_gmodainpc.lua
+++ b/lua/autorun/client/cl_gmodainpc.lua
@@ -1,3 +1,5 @@
+include("autorun/sh_ainpcs_debug.lua")
+
 local providers = include('providers/providers.lua')
 
 -- Context menu button
@@ -533,7 +535,7 @@ function drawaihud()
             requestBody.temperature = temperatureSlider:GetValue()
         end
 
-        PrintTable(requestBody)
+        AINPCS.DebugPrintTable(requestBody)
         net.Start("SendNPCInfo")
         net.WriteTable(requestBody)
         net.SendToServer()

--- a/lua/autorun/client/cl_gmodainpc.lua
+++ b/lua/autorun/client/cl_gmodainpc.lua
@@ -531,6 +531,8 @@ function drawaihud()
             max_tokens = math.floor(maxTokensSlider:GetValue()),
         }
 
+        requestBody.reasoning = currentReasoningChoice
+
         if temperatureSlider:IsVisible() then
             requestBody.temperature = temperatureSlider:GetValue()
         end

--- a/lua/autorun/client/cl_gmodainpc.lua
+++ b/lua/autorun/client/cl_gmodainpc.lua
@@ -11,7 +11,7 @@ list.Set("DesktopWindows", "ai_menu", {
 local modelPanel
 function drawaihud()
     local frame = vgui.Create("DFrame") -- Create a frame for the character selection panel
-    frame:SetSize(400, 480) -- Set the size of the frame
+    frame:SetSize(460, 580) -- Set the size of the frame with extra space for sliders
     frame:SetTitle("Character Selection") -- Set the title of the frame
     frame:Center() -- Center the frame on the screen
     frame:MakePopup() -- Make the frame a popup
@@ -23,7 +23,7 @@ function drawaihud()
     -- Left: 3D model display
     modelPanel = vgui.Create("DModelPanel", frame)
     modelPanel:Dock(LEFT)
-    modelPanel:SetSize(200, 0)
+    modelPanel:SetSize(220, 0)
     modelPanel:SetModel("models/humans/group01/male_07.mdl")
     modelPanel:SetFOV(48)
     modelPanel.LayoutEntity = function(self, ent)
@@ -35,6 +35,24 @@ function drawaihud()
     local rightPanel = vgui.Create("DPanel", frame)
     rightPanel:Dock(FILL)
     rightPanel:SetBackgroundColor(Color(116, 170, 156))
+
+    local currentProviderId = "openai"
+    local currentProviderData = nil
+    local currentModelChoice = nil
+    local currentReasoningChoice = nil
+
+    local defaultLimits = {
+        max_tokens = { min = 128, max = 4096, default = 2048 },
+        temperature = { min = 0, max = 2, default = 1 },
+    }
+
+    local providerDropdown
+    local modelDropdown
+    local modelTextEntry
+    local maxTokensSlider
+    local temperatureSlider
+    local reasoningLabel
+    local reasoningDropdown
 
     -- AI Personality
     local nameLabel = vgui.Create("DLabel", rightPanel)
@@ -49,7 +67,7 @@ function drawaihud()
     local providerLabel = vgui.Create("DLabel", rightPanel)
     providerLabel:SetText("Provider:")
     providerLabel:SetPos(10, 60)
-    local providerDropdown = vgui.Create("DComboBox", rightPanel)
+    providerDropdown = vgui.Create("DComboBox", rightPanel)
     providerDropdown:SetPos(10, 80)
     providerDropdown:SetSize(170, 20)
     providerDropdown:AddChoice("OpenAI", "openai", true)
@@ -69,44 +87,13 @@ function drawaihud()
     local modelLabel = vgui.Create("DLabel", rightPanel)
     modelLabel:SetText("Model:")
     modelLabel:SetPos(10, 160)
-    local modelDropdown = vgui.Create("DComboBox", rightPanel)
+    modelDropdown = vgui.Create("DComboBox", rightPanel)
     modelDropdown:SetPos(10, 180)
     modelDropdown:SetSize(170, 20)
-    local modelTextEntry = vgui.Create("DTextEntry", rightPanel)
+    modelTextEntry = vgui.Create("DTextEntry", rightPanel)
     modelTextEntry:SetPos(10, 180)
     modelTextEntry:SetSize(170, 20)
     modelTextEntry:SetVisible(false)
-
-    -- Populate initial model list
-    local initialModels = providers.get("openai").models or {}
-    if #initialModels > 0 then
-        for _, m in ipairs(initialModels) do modelDropdown:AddChoice(m) end
-        modelDropdown:ChooseOptionID(1)
-    else
-        modelDropdown:SetVisible(false)
-        modelTextEntry:SetVisible(true)
-    end
-
-    -- Provider change handler
-    function providerDropdown:OnSelect(self, idx, data)
-        if data == "ollama" then
-            hostnameEntry:SetEditable(true)
-        else
-            hostnameEntry:SetEditable(false)
-        end
-
-        local models = providers.get(data).models or {}
-        modelDropdown:Clear()
-        if #models > 0 then
-            modelDropdown:SetVisible(true)
-            modelTextEntry:SetVisible(false)
-            for _, m in ipairs(models) do modelDropdown:AddChoice(m) end
-            modelDropdown:ChooseOptionID(1)
-        else
-            modelDropdown:SetVisible(false)
-            modelTextEntry:SetVisible(true)
-        end
-    end
 
     -- NPC selection
     local npcLabel = vgui.Create("DLabel", rightPanel)
@@ -116,7 +103,9 @@ function drawaihud()
     npcDropdown:SetPos(10, 230)
     npcDropdown:SetSize(170, 20)
     npcDropdown:SetValue("npc_citizen")
-    function npcDropdown:OnSelect(self, idx, data)
+    local selectedNPCData
+    function npcDropdown:OnSelect(index, value, data)
+        selectedNPCData = data
         net.Start("GetNPCModel")
         net.WriteTable(data)
         net.SendToServer()
@@ -126,6 +115,10 @@ function drawaihud()
         npcDropdown:AddChoice(npcId, npcData)
     end
     npcDropdown:ChooseOptionID(1)
+    if not selectedNPCData then
+        local selectedPanel = npcDropdown:GetSelected()
+        selectedNPCData = selectedPanel and selectedPanel.Data
+    end
 
     -- API key
     local apiKeyLabel = vgui.Create("DLabel", rightPanel)
@@ -150,24 +143,254 @@ function drawaihud()
     local TTSButton = vgui.Create("DCheckBoxLabel", rightPanel)
     TTSButton:SetText("Text to Speech")
     TTSButton:SetPos(10, 330)
-    TTSButton:SetSize(170, 20)
+    TTSButton:SetSize(210, 20)
     TTSButton:SetValue(0)
+
+    -- Generation controls
+    maxTokensSlider = vgui.Create("DNumSlider", rightPanel)
+    maxTokensSlider:SetText("Max Tokens")
+    maxTokensSlider:SetPos(10, 360)
+    maxTokensSlider:SetSize(210, 40)
+    maxTokensSlider:SetMin(128)
+    maxTokensSlider:SetMax(4096)
+    maxTokensSlider:SetDecimals(0)
+    maxTokensSlider:SetValue(2048)
+
+    temperatureSlider = vgui.Create("DNumSlider", rightPanel)
+    temperatureSlider:SetText("Temperature")
+    temperatureSlider:SetPos(10, 400)
+    temperatureSlider:SetSize(210, 40)
+    temperatureSlider:SetMin(0)
+    temperatureSlider:SetMax(2)
+    temperatureSlider:SetDecimals(2)
+    temperatureSlider:SetValue(1)
+
+    reasoningLabel = vgui.Create("DLabel", rightPanel)
+    reasoningLabel:SetText("Reasoning Effort:")
+    reasoningLabel:SetPos(10, 440)
+    reasoningLabel:SetSize(210, 20)
+    reasoningLabel:SetVisible(false)
+
+    reasoningDropdown = vgui.Create("DComboBox", rightPanel)
+    reasoningDropdown:SetPos(10, 460)
+    reasoningDropdown:SetSize(210, 20)
+    reasoningDropdown:SetVisible(false)
+
+    local function toTitleCase(value)
+        if not value or value == "" then return "" end
+        return string.upper(string.sub(value, 1, 1)) .. string.sub(value, 2)
+    end
+
+    local function clampValue(value, minValue, maxValue)
+        if value == nil then
+            if minValue and maxValue then
+                return math.Clamp((minValue + maxValue) * 0.5, minValue, maxValue)
+            end
+            return minValue or maxValue or 0
+        end
+
+        if minValue and value < minValue then value = minValue end
+        if maxValue and value > maxValue then value = maxValue end
+        return value
+    end
+
+    local function applyMaxTokens(range)
+        local limits = range or defaultLimits.max_tokens
+        local minValue = limits.min or defaultLimits.max_tokens.min
+        local maxValue = limits.max or defaultLimits.max_tokens.max
+        local defaultValue = limits.default or defaultLimits.max_tokens.default
+
+        maxTokensSlider:SetMin(minValue)
+        maxTokensSlider:SetMax(maxValue)
+        maxTokensSlider:SetDecimals(0)
+
+        local currentValue = maxTokensSlider:GetValue()
+        if currentValue < minValue or currentValue > maxValue then
+            currentValue = defaultValue
+        end
+        maxTokensSlider:SetValue(clampValue(currentValue, minValue, maxValue))
+    end
+
+    local function applyTemperature(range)
+        local limits = range or defaultLimits.temperature
+        local minValue = limits.min or defaultLimits.temperature.min
+        local maxValue = limits.max or defaultLimits.temperature.max
+        local defaultValue = limits.default or defaultLimits.temperature.default
+        local decimals = limits.decimals or 2
+
+        temperatureSlider:SetMin(minValue)
+        temperatureSlider:SetMax(maxValue)
+        temperatureSlider:SetDecimals(decimals)
+
+        local currentValue = temperatureSlider:GetValue()
+        if currentValue < minValue or currentValue > maxValue then
+            currentValue = defaultValue
+        end
+        temperatureSlider:SetValue(clampValue(currentValue, minValue, maxValue))
+
+        local locked = minValue == maxValue
+        temperatureSlider:SetVisible(not locked)
+        temperatureSlider:SetEnabled(not locked)
+        if locked then
+            temperatureSlider:SetValue(minValue)
+        end
+    end
+
+    local function applyReasoning(options)
+        if istable(options) and #options > 0 then
+            reasoningLabel:SetVisible(true)
+            reasoningDropdown:SetVisible(true)
+            reasoningDropdown:Clear()
+
+            local matched = false
+            for idx, effort in ipairs(options) do
+                local label = toTitleCase(effort)
+                reasoningDropdown:AddChoice(label, effort)
+                if effort == currentReasoningChoice then
+                    reasoningDropdown:ChooseOptionID(idx)
+                    matched = true
+                end
+            end
+
+            if not matched then
+                reasoningDropdown:ChooseOptionID(1)
+                local selectedPanel = reasoningDropdown:GetSelected()
+                currentReasoningChoice = selectedPanel and selectedPanel.Data or options[1]
+            end
+        else
+            reasoningLabel:SetVisible(false)
+            reasoningDropdown:SetVisible(false)
+            reasoningDropdown:Clear()
+            currentReasoningChoice = nil
+        end
+    end
+
+    local function applyModelSettings(choice)
+        currentModelChoice = choice
+        local info = choice and choice.settings or nil
+        applyMaxTokens(info and info.max_tokens or nil)
+        applyTemperature(info and info.temperature or nil)
+        applyReasoning(info and info.reasoning or nil)
+    end
+
+    local function buildModelChoices(providerData)
+        local choices = {}
+        if not providerData then return choices end
+
+        if providerData.modelOrder and providerData.models then
+            for _, key in ipairs(providerData.modelOrder) do
+                local info = providerData.models[key]
+                if info then
+                    table.insert(choices, {
+                        id = key,
+                        label = info.label or key,
+                        settings = info
+                    })
+                end
+            end
+            return choices
+        end
+
+        if istable(providerData.models) then
+            if #providerData.models > 0 then
+                for _, entry in ipairs(providerData.models) do
+                    if isstring(entry) then
+                        table.insert(choices, { id = entry, label = entry })
+                    elseif istable(entry) then
+                        local id = entry.id or entry.name or entry.label
+                        if id then
+                            table.insert(choices, {
+                                id = id,
+                                label = entry.label or id,
+                                settings = entry
+                            })
+                        end
+                    end
+                end
+            else
+                for key, entry in pairs(providerData.models) do
+                    if istable(entry) then
+                        table.insert(choices, {
+                            id = key,
+                            label = entry.label or key,
+                            settings = entry
+                        })
+                    elseif isstring(entry) then
+                        table.insert(choices, { id = key, label = entry })
+                    end
+                end
+                table.sort(choices, function(a, b) return a.label < b.label end)
+            end
+        end
+
+        return choices
+    end
+
+    local function populateModels(providerId)
+        currentProviderData = providers.get(providerId)
+        modelDropdown:Clear()
+
+        local choices = currentProviderData and buildModelChoices(currentProviderData) or {}
+        if #choices > 0 then
+            modelDropdown:SetVisible(true)
+            modelTextEntry:SetVisible(false)
+            for _, choice in ipairs(choices) do
+                modelDropdown:AddChoice(choice.label, choice)
+            end
+            modelDropdown:ChooseOptionID(1)
+        else
+            modelDropdown:SetVisible(false)
+            modelTextEntry:SetVisible(true)
+            modelTextEntry:SetValue("")
+            applyModelSettings(nil)
+        end
+    end
+
+    function providerDropdown:OnSelect(index, value, data)
+        currentProviderId = data or value
+        if currentProviderId == "ollama" then
+            hostnameEntry:SetEditable(true)
+        else
+            hostnameEntry:SetEditable(false)
+        end
+        populateModels(currentProviderId)
+    end
+
+    function modelDropdown:OnSelect(index, value, data)
+        if istable(data) then
+            applyModelSettings(data)
+        else
+            applyModelSettings({ id = value })
+        end
+    end
+
+    function reasoningDropdown:OnSelect(index, value, data)
+        currentReasoningChoice = data or value
+    end
+
+    hostnameEntry:SetEditable(false)
+    populateModels(currentProviderId)
 
     -- Create NPC button
     local createButton = vgui.Create("DButton", rightPanel)
     createButton:SetText("Create NPC")
-    createButton:SetPos(10, 360)
-    createButton:SetSize(170, 60)
+    createButton:SetPos(10, 500)
+    createButton:SetSize(210, 60)
     createButton.DoClick = function()
         inputapikey = apiKeyEntry:GetValue()
         local APIKEY = freeAPIButton:GetChecked() and
             "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" or
             apiKeyEntry:GetValue()
 
-        local _, selectedNPC = npcDropdown:GetSelected()
-        local _, provider = providerDropdown:GetSelected()
-        -- Choose model or input
-        local chosenModel = modelDropdown:IsVisible() and modelDropdown:GetValue() or modelTextEntry:GetValue()
+        local selectedNPCPanel = npcDropdown:GetSelected()
+        local selectedNPC = selectedNPCPanel and selectedNPCPanel.Data or selectedNPCData
+
+        local chosenModel
+        if modelDropdown:IsVisible() then
+            chosenModel = currentModelChoice and currentModelChoice.id or modelDropdown:GetValue()
+        else
+            chosenModel = modelTextEntry:GetValue()
+        end
 
         local requestBody = {
             apiKey = APIKEY,
@@ -175,9 +398,14 @@ function drawaihud()
             personality = aiLinkEntry:GetValue(),
             NPCData = selectedNPC,
             enableTTS = TTSButton:GetChecked(),
-            provider = provider,
+            provider = currentProviderId,
             model = chosenModel,
+            max_tokens = math.floor(maxTokensSlider:GetValue()),
         }
+
+        if temperatureSlider:IsVisible() then
+            requestBody.temperature = temperatureSlider:GetValue()
+        end
 
         PrintTable(requestBody)
         net.Start("SendNPCInfo")

--- a/lua/autorun/client/cl_gmodainpc.lua
+++ b/lua/autorun/client/cl_gmodainpc.lua
@@ -11,7 +11,7 @@ list.Set("DesktopWindows", "ai_menu", {
 local modelPanel
 function drawaihud()
     local frame = vgui.Create("DFrame") -- Create a frame for the character selection panel
-    frame:SetSize(460, 580) -- Set the size of the frame with extra space for sliders
+    frame:SetSize(960, 580) -- Expand the frame for the new column layout
     frame:SetTitle("Character Selection") -- Set the title of the frame
     frame:Center() -- Center the frame on the screen
     frame:MakePopup() -- Make the frame a popup
@@ -20,10 +20,31 @@ function drawaihud()
     frame:SetScreenLock(true) -- Lock the mouse to the frame
     frame:SetIcon("materials/gptlogo/ChatGPT_logo.svg.png") -- Set the icon of the frame
 
-    -- Left: 3D model display
-    modelPanel = vgui.Create("DModelPanel", frame)
-    modelPanel:Dock(LEFT)
-    modelPanel:SetSize(220, 0)
+    local labelColor = Color(255, 255, 255)
+
+    local contentPanel = vgui.Create("DPanel", frame)
+    contentPanel:Dock(FILL)
+    contentPanel:DockPadding(10, 10, 10, 10)
+    contentPanel.Paint = nil
+
+    local modelColumn = vgui.Create("DPanel", contentPanel)
+    modelColumn:Dock(LEFT)
+    modelColumn:SetWide(220)
+    modelColumn:DockMargin(0, 0, 10, 0)
+    modelColumn:DockPadding(10, 10, 10, 10)
+    modelColumn.Paint = nil
+
+    local modelHeader = vgui.Create("DLabel", modelColumn)
+    modelHeader:SetText("3D model view")
+    modelHeader:SetFont("Trebuchet24")
+    modelHeader:SetContentAlignment(4)
+    modelHeader:Dock(TOP)
+    modelHeader:SetTall(24)
+    modelHeader:DockMargin(0, 0, 0, 8)
+    modelHeader:SetTextColor(labelColor)
+
+    modelPanel = vgui.Create("DModelPanel", modelColumn)
+    modelPanel:Dock(FILL)
     modelPanel:SetModel("models/humans/group01/male_07.mdl")
     modelPanel:SetFOV(48)
     modelPanel.LayoutEntity = function(self, ent)
@@ -31,10 +52,33 @@ function drawaihud()
         ent:SetAngles(Angle(0, RealTime() * 100, 0))
     end
 
-    -- Right: Controls
-    local rightPanel = vgui.Create("DPanel", frame)
-    rightPanel:Dock(FILL)
-    rightPanel:SetBackgroundColor(Color(116, 170, 156))
+    local function createColumn(title, width, marginRight)
+        local container = vgui.Create("DPanel", contentPanel)
+        container:Dock(LEFT)
+        container:SetWide(width)
+        container:DockMargin(0, 0, marginRight or 10, 0)
+        container:DockPadding(10, 10, 10, 10)
+        container.Paint = nil
+
+        local header = vgui.Create("DLabel", container)
+        header:SetText(title)
+        header:SetFont("Trebuchet24")
+        header:SetContentAlignment(4)
+        header:Dock(TOP)
+        header:SetTall(24)
+        header:DockMargin(0, 0, 0, 8)
+        header:SetTextColor(labelColor)
+
+        local body = vgui.Create("DScrollPanel", container)
+        body:Dock(FILL)
+        body:SetPaintBackground(false)
+
+        return body
+    end
+
+    local personalityBody = createColumn("AI Personality", 220)
+    local providerBody = createColumn("Model selector", 220)
+    local settingsBody = createColumn("Model settings", 240, 0)
 
     local currentProviderId = "openai"
     local currentProviderData = nil
@@ -55,53 +99,84 @@ function drawaihud()
     local reasoningDropdown
 
     -- AI Personality
-    local nameLabel = vgui.Create("DLabel", rightPanel)
+    local nameLabel = personalityBody:Add("DLabel")
     nameLabel:SetText("AI Personality:")
-    nameLabel:SetPos(10, 10)
-    nameLabel:SetSize(170, 20)
-    local aiLinkEntry = vgui.Create("DTextEntry", rightPanel)
-    aiLinkEntry:SetPos(10, 30)
-    aiLinkEntry:SetSize(170, 20)
+    nameLabel:SetContentAlignment(4)
+    nameLabel:SetTall(20)
+    nameLabel:Dock(TOP)
+    nameLabel:DockMargin(0, 0, 0, 4)
+    nameLabel:SetTextColor(labelColor)
+
+    local aiLinkEntry = personalityBody:Add("DTextEntry")
+    aiLinkEntry:Dock(TOP)
+    aiLinkEntry:SetTall(48)
+    aiLinkEntry:DockMargin(0, 0, 0, 12)
 
     -- Provider selection
-    local providerLabel = vgui.Create("DLabel", rightPanel)
+    local providerLabel = providerBody:Add("DLabel")
     providerLabel:SetText("Provider:")
-    providerLabel:SetPos(10, 60)
-    providerDropdown = vgui.Create("DComboBox", rightPanel)
-    providerDropdown:SetPos(10, 80)
-    providerDropdown:SetSize(170, 20)
+    providerLabel:SetContentAlignment(4)
+    providerLabel:SetTall(20)
+    providerLabel:Dock(TOP)
+    providerLabel:DockMargin(0, 0, 0, 4)
+    providerLabel:SetTextColor(labelColor)
+
+    providerDropdown = providerBody:Add("DComboBox")
+    providerDropdown:Dock(TOP)
+    providerDropdown:SetTall(24)
+    providerDropdown:DockMargin(0, 0, 0, 12)
     providerDropdown:AddChoice("OpenAI", "openai", true)
     providerDropdown:AddChoice("OpenRouter", "openrouter")
     providerDropdown:AddChoice("Groq", "groq")
     providerDropdown:AddChoice("Ollama", "ollama")
 
     -- Hostname entry
-    local hostnameLabel = vgui.Create("DLabel", rightPanel)
+    local hostnameLabel = providerBody:Add("DLabel")
     hostnameLabel:SetText("Hostname:")
-    hostnameLabel:SetPos(10, 110)
-    local hostnameEntry = vgui.Create("DTextEntry", rightPanel)
-    hostnameEntry:SetPos(10, 130)
-    hostnameEntry:SetSize(170, 20)
+    hostnameLabel:SetContentAlignment(4)
+    hostnameLabel:SetTall(20)
+    hostnameLabel:Dock(TOP)
+    hostnameLabel:DockMargin(0, 0, 0, 4)
+    hostnameLabel:SetTextColor(labelColor)
+
+    local hostnameEntry = providerBody:Add("DTextEntry")
+    hostnameEntry:Dock(TOP)
+    hostnameEntry:SetTall(24)
+    hostnameEntry:DockMargin(0, 0, 0, 12)
 
     -- Model selection or input
-    local modelLabel = vgui.Create("DLabel", rightPanel)
+    local modelLabel = providerBody:Add("DLabel")
     modelLabel:SetText("Model:")
-    modelLabel:SetPos(10, 160)
-    modelDropdown = vgui.Create("DComboBox", rightPanel)
-    modelDropdown:SetPos(10, 180)
-    modelDropdown:SetSize(170, 20)
-    modelTextEntry = vgui.Create("DTextEntry", rightPanel)
-    modelTextEntry:SetPos(10, 180)
-    modelTextEntry:SetSize(170, 20)
+    modelLabel:SetContentAlignment(4)
+    modelLabel:SetTall(20)
+    modelLabel:Dock(TOP)
+    modelLabel:DockMargin(0, 0, 0, 4)
+    modelLabel:SetTextColor(labelColor)
+
+    modelDropdown = providerBody:Add("DComboBox")
+    modelDropdown:Dock(TOP)
+    modelDropdown:SetTall(24)
+    modelDropdown:DockMargin(0, 0, 0, 8)
+
+    modelTextEntry = providerBody:Add("DTextEntry")
+    modelTextEntry:Dock(TOP)
+    modelTextEntry:SetTall(24)
+    modelTextEntry:DockMargin(0, 0, 0, 8)
     modelTextEntry:SetVisible(false)
 
     -- NPC selection
-    local npcLabel = vgui.Create("DLabel", rightPanel)
+    local npcLabel = providerBody:Add("DLabel")
     npcLabel:SetText("Select NPC:")
-    npcLabel:SetPos(10, 210)
-    local npcDropdown = vgui.Create("DComboBox", rightPanel)
-    npcDropdown:SetPos(10, 230)
-    npcDropdown:SetSize(170, 20)
+    npcLabel:SetContentAlignment(4)
+    npcLabel:SetTall(20)
+    npcLabel:Dock(TOP)
+    npcLabel:DockMargin(0, 12, 0, 4)
+    npcLabel:SetTextColor(labelColor)
+
+    local npcDropdown = providerBody:Add("DComboBox")
+    npcDropdown:Dock(TOP)
+    npcDropdown:SetTall(24)
+    npcDropdown:DockMargin(0, 0, 0, 12)
     npcDropdown:SetValue("npc_citizen")
     local selectedNPCData
     function npcDropdown:OnSelect(index, value, data)
@@ -121,59 +196,77 @@ function drawaihud()
     end
 
     -- API key
-    local apiKeyLabel = vgui.Create("DLabel", rightPanel)
+    local apiKeyLabel = settingsBody:Add("DLabel")
     apiKeyLabel:SetText("API Key:")
-    apiKeyLabel:SetPos(10, 260)
-    local apiKeyEntry = vgui.Create("DTextEntry", rightPanel)
-    apiKeyEntry:SetPos(10, 280)
-    apiKeyEntry:SetSize(170, 20)
+    apiKeyLabel:SetContentAlignment(4)
+    apiKeyLabel:SetTall(20)
+    apiKeyLabel:Dock(TOP)
+    apiKeyLabel:DockMargin(0, 0, 0, 4)
+    apiKeyLabel:SetTextColor(labelColor)
+
+    local apiKeyEntry = settingsBody:Add("DTextEntry")
+    apiKeyEntry:Dock(TOP)
+    apiKeyEntry:SetTall(24)
+    apiKeyEntry:DockMargin(0, 0, 0, 12)
     apiKeyEntry:SetText(inputapikey)
 
     -- Free API toggle
-    local freeAPIButton = vgui.Create("DCheckBoxLabel", rightPanel)
+    local freeAPIButton = settingsBody:Add("DCheckBoxLabel")
     freeAPIButton:SetText("Free API")
-    freeAPIButton:SetPos(10, 310)
-    freeAPIButton:SetSize(170, 20)
+    freeAPIButton:SetTall(20)
+    freeAPIButton:Dock(TOP)
+    freeAPIButton:DockMargin(0, 0, 0, 8)
+    freeAPIButton:SetTextColor(labelColor)
     freeAPIButton.OnChange = function(self, value)
         apiKeyEntry:SetText(value and "" or apiKeyEntry:GetText())
         apiKeyEntry:SetEditable(not value)
     end
 
     -- Text-to-speech toggle
-    local TTSButton = vgui.Create("DCheckBoxLabel", rightPanel)
+    local TTSButton = settingsBody:Add("DCheckBoxLabel")
     TTSButton:SetText("Text to Speech")
-    TTSButton:SetPos(10, 330)
-    TTSButton:SetSize(210, 20)
+    TTSButton:SetTall(20)
+    TTSButton:Dock(TOP)
+    TTSButton:DockMargin(0, 0, 0, 12)
     TTSButton:SetValue(0)
+    TTSButton:SetTextColor(labelColor)
 
     -- Generation controls
-    maxTokensSlider = vgui.Create("DNumSlider", rightPanel)
+    maxTokensSlider = settingsBody:Add("DNumSlider")
     maxTokensSlider:SetText("Max Tokens")
-    maxTokensSlider:SetPos(10, 360)
-    maxTokensSlider:SetSize(210, 40)
+    maxTokensSlider.Label:SetTextColor(labelColor)
+    maxTokensSlider:SetTall(48)
+    maxTokensSlider:Dock(TOP)
+    maxTokensSlider:DockMargin(0, 0, 0, 12)
     maxTokensSlider:SetMin(128)
     maxTokensSlider:SetMax(4096)
     maxTokensSlider:SetDecimals(0)
     maxTokensSlider:SetValue(2048)
 
-    temperatureSlider = vgui.Create("DNumSlider", rightPanel)
+    temperatureSlider = settingsBody:Add("DNumSlider")
     temperatureSlider:SetText("Temperature")
-    temperatureSlider:SetPos(10, 400)
-    temperatureSlider:SetSize(210, 40)
+    temperatureSlider.Label:SetTextColor(labelColor)
+    temperatureSlider:SetTall(48)
+    temperatureSlider:Dock(TOP)
+    temperatureSlider:DockMargin(0, 0, 0, 12)
     temperatureSlider:SetMin(0)
     temperatureSlider:SetMax(2)
     temperatureSlider:SetDecimals(2)
     temperatureSlider:SetValue(1)
 
-    reasoningLabel = vgui.Create("DLabel", rightPanel)
+    reasoningLabel = settingsBody:Add("DLabel")
     reasoningLabel:SetText("Reasoning Effort:")
-    reasoningLabel:SetPos(10, 440)
-    reasoningLabel:SetSize(210, 20)
+    reasoningLabel:SetContentAlignment(4)
+    reasoningLabel:SetTall(20)
+    reasoningLabel:Dock(TOP)
+    reasoningLabel:DockMargin(0, 12, 0, 4)
     reasoningLabel:SetVisible(false)
+    reasoningLabel:SetTextColor(labelColor)
 
-    reasoningDropdown = vgui.Create("DComboBox", rightPanel)
-    reasoningDropdown:SetPos(10, 460)
-    reasoningDropdown:SetSize(210, 20)
+    reasoningDropdown = settingsBody:Add("DComboBox")
+    reasoningDropdown:Dock(TOP)
+    reasoningDropdown:SetTall(24)
+    reasoningDropdown:DockMargin(0, 0, 0, 12)
     reasoningDropdown:SetVisible(false)
 
     local function toTitleCase(value)
@@ -372,10 +465,11 @@ function drawaihud()
     populateModels(currentProviderId)
 
     -- Create NPC button
-    local createButton = vgui.Create("DButton", rightPanel)
+    local createButton = settingsBody:Add("DButton")
     createButton:SetText("Create NPC")
-    createButton:SetPos(10, 500)
-    createButton:SetSize(210, 60)
+    createButton:SetTall(60)
+    createButton:Dock(TOP)
+    createButton:DockMargin(0, 20, 0, 0)
     createButton.DoClick = function()
         inputapikey = apiKeyEntry:GetValue()
         local APIKEY = freeAPIButton:GetChecked() and

--- a/lua/autorun/server/sv_gmodainpc.lua
+++ b/lua/autorun/server/sv_gmodainpc.lua
@@ -43,6 +43,7 @@ net.Receive("SendNPCInfo", function(len, ply)
     print("Data received: " .. util.TableToJSON(data))
 
     local apiKey = data["apiKey"]
+    local providerId = data["provider"]
     -- Please dont steal our API key, we are poor
     -- TODO Add Encrpytion Decrpytion crap to obfuscate api key
     if apiKey == "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" then
@@ -51,7 +52,7 @@ net.Receive("SendNPCInfo", function(len, ply)
         print("API key received: " .. apiKey)
     end
 
-    if apiKey == "" then
+    if apiKey == "" and providerId ~= "ollama" then
         ply:ChatPrint("Invalid API key.")
         return nil
     end

--- a/lua/autorun/server/sv_gmodainpc.lua
+++ b/lua/autorun/server/sv_gmodainpc.lua
@@ -78,8 +78,11 @@ net.Receive("SendNPCInfo", function(len, ply)
     spawnedNPC[key]["provider"] = data["provider"]
     spawnedNPC[key]["hostname"] = data["hostname"]
     spawnedNPC[key]["apiKey"] = apiKey
-    spawnedNPC[key]["max_tokens"] = 50
-    spawnedNPC[key]["temperature"] = 0.7
+    local maxTokens = tonumber(data["max_tokens"])
+    spawnedNPC[key]["max_tokens"] = maxTokens or 2048
+    local temperature = tonumber(data["temperature"])
+    spawnedNPC[key]["temperature"] = temperature
+    spawnedNPC[key]["reasoning"] = data["reasoning"]
     spawnedNPC[key]["enableTTS"] = data["enableTTS"]
     spawnedNPC[key]["model"] = data["model"]
 

--- a/lua/autorun/sh_ainpcs_debug.lua
+++ b/lua/autorun/sh_ainpcs_debug.lua
@@ -1,0 +1,29 @@
+if SERVER then
+    AddCSLuaFile()
+end
+
+AINPCS = AINPCS or {}
+
+local function isDeveloperEnabled()
+    local conVar = GetConVar and GetConVar("developer")
+    if not conVar then return false end
+    return conVar:GetInt() == 1
+end
+
+function AINPCS.IsDeveloperEnabled()
+    return isDeveloperEnabled()
+end
+
+function AINPCS.DebugPrint(...)
+    if not isDeveloperEnabled() then return end
+    print(...)
+end
+
+function AINPCS.DebugPrintTable(tbl, indent)
+    if not isDeveloperEnabled() then return end
+    if indent ~= nil then
+        PrintTable(tbl, indent)
+    else
+        PrintTable(tbl)
+    end
+end

--- a/lua/providers/groq.lua
+++ b/lua/providers/groq.lua
@@ -1,26 +1,45 @@
 local groqProvider = {}
 
 groqProvider.models = {
-    "gemma2-9b-it",
-    "llama-3.3-70b-versatile",
-    "llama-3.1-8b-instant",
-    "llama3-70b-8192",
-    "llama3-8b-8192",
-    "mixtral-8x7b-32768",
-    "allam-2-7b",
-    "deepseek-r1-distill-llama-70b",
-    "meta-llama/llama-4-maverick-17b-128e-instruct",
-    "meta-llama/llama-4-scout-17b-16e-instruct",
-    "mistral-saba-24b",
-    "qwen-qwq-32b"
+    ["llama-3.3-70b-versatile"] = {
+        label = "LLaMA 3.3 70B",
+        max_tokens = { min = 1, max = 32768, default = 2048 },
+        temperature = { min = 0, max = 2, default = 1 },
+    },
+    ["llama-3.1-8b-instant"] = {
+        label = "LLaMA 3.1 8B",
+        max_tokens = { min = 1, max = 131072, default = 2048 },
+        temperature = { min = 0, max = 2, default = 1 },
+    },
+    ["openai/gpt-oss-120b"] = {
+        label = "GPT OSS 120B",
+        max_tokens = { min = 1, max = 65536, default = 2048 },
+        temperature = { min = 0, max = 2, default = 1 },
+    },
+    ["openai/gpt-oss-20b"] = {
+        label = "GPT OSS 20B",
+        max_tokens = { min = 1, max = 65536, default = 2048 },
+        temperature = { min = 0, max = 2, default = 1 },
+    },
+    ["meta-llama/llama-4-maverick-17b-128e-instruct"] = {
+        label = "LLaMA 4 Maverick 17B 128E",
+        max_tokens = { min = 1, max = 8192, default = 2048 },
+        temperature = { min = 0, max = 2, default = 1 },
+    },
+    ["meta-llama/llama-4-scout-17b-16e-instruct"] = {
+        label = "LLaMA 4 Scout 17B 16E",
+        max_tokens = { min = 1, max = 8192, default = 2048 },
+        temperature = { min = 0, max = 2, default = 1 },
+    },
+    ["qwen/qwen3-32b"] = {
+        label = "Qwen3-32B",
+        max_tokens = { min = 1, max = 40960, default = 2048 },
+        temperature = { min = 0, max = 2, default = 1 }
+    }
 }
 
 if SERVER then
     function groqProvider.request(npc, callback)
-        local function correctFloatToInt(jsonString)
-            return string.gsub(jsonString, '(%d+)%.0', '%1')
-        end
-
         local requestBody = {
             model = npc["model"],
             messages = npc["history"],
@@ -36,7 +55,7 @@ if SERVER then
                 ["Content-Type"] = "application/json",
                 ["Authorization"] = "Bearer " .. npc["apiKey"] -- Access the API key from the Global table
             },
-            body = correctFloatToInt(util.TableToJSON(requestBody)), -- tableToJSON changes integers to float
+            body = util.TableToJSON(requestBody),
 
             success = function(code, body, headers)
                 -- Parse the JSON response from the GPT-3 API

--- a/lua/providers/ollama.lua
+++ b/lua/providers/ollama.lua
@@ -33,8 +33,8 @@ if SERVER then
 
             success = function(code, body, headers)
                 local loggedBody = body or "<empty response>"
-                print("[AI-NPCs][Ollama] Response code: " .. tostring(code))
-                print("[AI-NPCs][Ollama] Response body: " .. loggedBody)
+                AINPCS.DebugPrint("[AI-NPCs][Ollama] Response code: " .. tostring(code))
+                AINPCS.DebugPrint("[AI-NPCs][Ollama] Response body: " .. loggedBody)
                 -- Parse the JSON response from the GPT-3 API
                 local response = util.JSONToTable(body)
 

--- a/lua/providers/ollama.lua
+++ b/lua/providers/ollama.lua
@@ -4,10 +4,6 @@ ollamaProvider.models = {}
 
 if SERVER then
     function ollamaProvider.request(npc, callback)
-        local function correctFloatToInt(jsonString)
-            return string.gsub(jsonString, '(%d+)%.0', '%1')
-        end
-
         if not npc["hostname"] then
             ErrorNoHalt("Hostname not defined")
         end
@@ -20,17 +16,25 @@ if SERVER then
             stream = false
         }
 
+        local headers = {
+            ["Content-Type"] = "application/json"
+        }
+
+        if npc["apiKey"] and npc["apiKey"] ~= "" then
+            headers["Authorization"] = "Bearer " .. npc["apiKey"]
+        end
+
         HTTP({
             url = "http://" .. npc["hostname"] .. "/api/chat",
             type = "application/json",
             method = "post",
-            headers = {
-                ["Content-Type"] = "application/json",
-                ["Authorization"] = "Bearer " .. npc["apiKey"] -- Access the API key from the Global table
-            },
-            body = correctFloatToInt(util.TableToJSON(requestBody)), -- tableToJSON changes integers to float
+            headers = headers,
+            body = util.TableToJSON(requestBody),
 
             success = function(code, body, headers)
+                local loggedBody = body or "<empty response>"
+                print("[AI-NPCs][Ollama] Response code: " .. tostring(code))
+                print("[AI-NPCs][Ollama] Response body: " .. loggedBody)
                 -- Parse the JSON response from the GPT-3 API
                 local response = util.JSONToTable(body)
 

--- a/lua/providers/openai.lua
+++ b/lua/providers/openai.lua
@@ -72,6 +72,10 @@ if SERVER then
             max_completion_tokens = npc["max_tokens"], 
         }
 
+        if npc["reasoning"] ~= nil and npc["reasoning"] ~= "" then
+            requestBody.reasoning_effort = npc["reasoning"]
+        end
+
         if npc["temperature"] ~= nil then
             requestBody.temperature = npc["temperature"]
         end
@@ -86,6 +90,9 @@ if SERVER then
             body = util.TableToJSON(requestBody), -- tableToJSON changes integers to float
 
             success = function(code, body, headers)
+                local loggedBody = body or "<empty response>"
+                AINPCS.DebugPrint("[AI-NPCs][OpenAI] Response code: " .. tostring(code))
+                AINPCS.DebugPrint("[AI-NPCs][OpenAI] Response body: " .. loggedBody)
                 -- Parse the JSON response from the GPT-3 API
                 local response = util.JSONToTable(body)
 

--- a/lua/providers/openai.lua
+++ b/lua/providers/openai.lua
@@ -1,6 +1,10 @@
 local openAiProvider = {}
 
-openAiProvider.models = {
+openAiProvider.modelOrder = {
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5-nano",
+    "gpt-5-pro",
     "gpt-4o",
     "gpt-4o-mini",
     "gpt-4-turbo",
@@ -8,28 +12,78 @@ openAiProvider.models = {
     "gpt-3.5-turbo"
 }
 
+openAiProvider.models = {
+    ["gpt-5"] = {
+        label = "GPT-5",
+        max_tokens = { min = 128, max = 4096, default = 2048 },
+        temperature = { min = 1, max = 1, default = 1 },
+        reasoning = { "minimal", "low", "medium", "high" },
+    },
+    ["gpt-5-mini"] = {
+        label = "GPT-5 Mini",
+        max_tokens = { min = 128, max = 4096, default = 2048 },
+        temperature = { min = 1, max = 1, default = 1 },
+        reasoning = { "minimal", "low", "medium", "high" },
+    },
+    ["gpt-5-nano"] = {
+        label = "GPT-5 Nano",
+        max_tokens = { min = 128, max = 4096, default = 2048 },
+        temperature = { min = 1, max = 1, default = 1 },
+        reasoning = { "minimal", "low", "medium", "high" },
+    },
+    ["gpt-5-pro"] = {
+        label = "GPT-5 Pro",
+        max_tokens = { min = 128, max = 4096, default = 2048 },
+        temperature = { min = 1, max = 1, default = 1 },
+        reasoning = { "minimal", "low", "medium", "high" },
+    },
+    ["gpt-4o"] = {
+        label = "GPT-4o",
+        max_tokens = { min = 128, max = 4096, default = 2048 },
+        temperature = { min = 0, max = 2, default = 1 },
+    },
+    ["gpt-4o-mini"] = {
+        label = "GPT-4o Mini",
+        max_tokens = { min = 128, max = 4096, default = 2048 },
+        temperature = { min = 0, max = 2, default = 1 },
+    },
+    ["gpt-4-turbo"] = {
+        label = "GPT-4 Turbo",
+        max_tokens = { min = 128, max = 4096, default = 2048 },
+        temperature = { min = 0, max = 2, default = 1 },
+    },
+    ["gpt-4"] = {
+        label = "GPT-4",
+        max_tokens = { min = 128, max = 4096, default = 2048 },
+        temperature = { min = 0, max = 2, default = 1 },
+    },
+    ["gpt-3.5-turbo"] = {
+        label = "GPT-3.5 Turbo",
+        max_tokens = { min = 128, max = 4096, default = 2048 },
+        temperature = { min = 0, max = 2, default = 1 },
+    },
+}
+
 if SERVER then
     function openAiProvider.request(npc, callback)
-        local function correctFloatToInt(jsonString)
-            return string.gsub(jsonString, '(%d+)%.0', '%1')
-        end
-
         local requestBody = {
             model = npc["model"],
             messages = npc["history"],
-            max_tokens = npc["max_tokens"], 
-            temperature = npc["temperature"]
+            max_completion_tokens = npc["max_tokens"], 
         }
+
+        if npc["temperature"] ~= nil then
+            requestBody.temperature = npc["temperature"]
+        end
 
         HTTP({
             url = "https://api.openai.com/v1/chat/completions",
-            type = "application/json",
+            type = "application/json; charset=utf-8",
             method = "post",
             headers = {
-                ["Content-Type"] = "application/json",
                 ["Authorization"] = "Bearer " .. npc["apiKey"] -- Access the API key from the Global table
             },
-            body = correctFloatToInt(util.TableToJSON(requestBody)), -- tableToJSON changes integers to float
+            body = util.TableToJSON(requestBody), -- tableToJSON changes integers to float
 
             success = function(code, body, headers)
                 -- Parse the JSON response from the GPT-3 API

--- a/lua/providers/openrouter.lua
+++ b/lua/providers/openrouter.lua
@@ -6,10 +6,6 @@ openrouterProvider.models = {
 
 if SERVER then
     function openrouterProvider.request(npc, callback)
-        local function correctFloatToInt(jsonString)
-            return string.gsub(jsonString, '(%d+)%.0', '%1')
-        end
-
         local requestBody = {
             model = npc["model"],
             messages = npc["history"],
@@ -25,7 +21,7 @@ if SERVER then
                 ["Content-Type"] = "application/json",
                 ["Authorization"] = "Bearer " .. npc["apiKey"] -- Access the API key from the Global table
             },
-            body = correctFloatToInt(util.TableToJSON(requestBody)), -- tableToJSON changes integers to float
+            body = util.TableToJSON(requestBody),
 
             success = function(code, body, headers)
                 -- Parse the JSON response from the GPT-3 API

--- a/lua/providers/providers.lua
+++ b/lua/providers/providers.lua
@@ -1,7 +1,7 @@
 local providers = {}
 
 function providers.get(name)
-    print(name)
+    AINPCS.DebugPrint("Loading provider: " .. tostring(name))
     local provider
     if name == "openai" then
         provider = include("providers/openai.lua")


### PR DESCRIPTION
- Redesign the in-game configuration panel around a multi-column layout to surface model selection, personality, and settings side by side (`7d4939f`).
- Add max-token and temperature sliders plus a reasoning-effort dropdown, and refresh the available model lists for OpenAI and Groq (`a925a81`).
- Add full Ollama provider support, treat the API key as optional, and ensure outbound requests only include auth when supplied (`bda292c`).
- Funnel all project logging through debug helpers so console noise only appears while the `developer` convar is set to 1 (`03787d3`).

Redesigned UI preview:
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/394ced39-a1bf-4dd5-827d-55f332bf8070" />